### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
+# DalekJS is not maintained any longer :cry:
+
+We recommend [TestCafé](http://devexpress.github.io/testcafe/) for your automated browser testing needs.
+
+---
+
 dalek-internal-testsuite
 ========================
 
 > The content of this repository has been moved to [Dalek Core](https://github.com/dalekjs/dalek/blob/master/lib/dalek/testsuite.js)
 
-This has been done to simplify the installation process, get develeopment environments up & running more quickly.
-Not in the name of the doctor, but in the name of peace & sanity
+This has been done to simplify the installation process, get development environments up & running more quickly.
+Not in the name of the doctor, but in the name of peace & sanity.


### PR DESCRIPTION
# DalekJS is not maintained any longer :cry:

We recommend [TestCafé](http://devexpress.github.io/testcafe/) for your automated browser testing needs.